### PR TITLE
fixes small ui issues with center component alignment and flop events

### DIFF
--- a/next-poker-app/app/globals.css
+++ b/next-poker-app/app/globals.css
@@ -118,11 +118,12 @@ body {
 }
 
 .design-page-wrapper {
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  min-height: 100vh;
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   font-family: 'Outfit', sans-serif;
   color: var(--color-text-primary);
   -webkit-font-smoothing: antialiased;

--- a/next-poker-app/app/globals.css
+++ b/next-poker-app/app/globals.css
@@ -20,10 +20,15 @@
   }
 }
 
-body {
-  background: var(--background);
+html, body {
+  background: #020617;
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  min-height: 100%;
+}
+
+body {
+  background: #020617;
 }
 
 @theme {
@@ -129,6 +134,7 @@ body {
   -webkit-font-smoothing: antialiased;
   background-image: linear-gradient(135deg, #0f172a 0%, #020617 100%);
   background-attachment: fixed;
+  background-size: cover;
   display: flex;
   justify-content: center;
 }

--- a/next-poker-app/app/lib/tablePositions.ts
+++ b/next-poker-app/app/lib/tablePositions.ts
@@ -9,12 +9,12 @@ export const tablePositionByPlayers: Record<number, string[]> = {
 export const FULL_RING_SEAT_COUNT = 6;
 
 export const sixSeatLayout = [
-  { seat: 0, className: 'left-1/2 top-2 -translate-x-1/2' },
-  { seat: 1, className: 'right-4 top-16' },
-  { seat: 2, className: 'right-6 bottom-16' },
-  { seat: 3, className: 'left-1/2 bottom-2 -translate-x-1/2' },
-  { seat: 4, className: 'left-6 bottom-16' },
-  { seat: 5, className: 'left-4 top-16' },
+  { seat: 0, className: 'left-1/2 top-0 -translate-x-1/2' },
+  { seat: 1, className: 'right-[8%] top-[15%] translate-x-1/2' },
+  { seat: 2, className: 'right-[8%] bottom-[15%] translate-x-1/2' },
+  { seat: 3, className: 'left-1/2 bottom-0 -translate-x-1/2' },
+  { seat: 4, className: 'left-[8%] bottom-[15%] -translate-x-1/2' },
+  { seat: 5, className: 'left-[8%] top-[15%] -translate-x-1/2' },
 ] as const;
 
 export function getTablePosition(position: number, tableSize: number): string {

--- a/next-poker-app/app/play/components/CardSelector.tsx
+++ b/next-poker-app/app/play/components/CardSelector.tsx
@@ -58,6 +58,10 @@ export default function CardSelector({
                     </div>
                     <button onClick={() => setPendingRank(null)} className="text-[10px] text-[var(--color-text-secondary)] hover:text-white mt-0.5">&larr; Back to ranks</button>
                 </div>
+            ) : pickingFor === 'community' && communityCardsCount >= 5 ? (
+                <div className="py-6 text-center text-xs font-semibold text-emerald-400">
+                    Maximum 5 community cards reached. Click Confirm to continue.
+                </div>
             ) : (
                 <div className="grid grid-cols-7 gap-1">
                     {RANKS.map(r => {

--- a/next-poker-app/app/play/components/DealHoleCards.tsx
+++ b/next-poker-app/app/play/components/DealHoleCards.tsx
@@ -42,7 +42,7 @@ export default function DealHoleCards({
                 center={(
                     <div className="flex flex-col items-center gap-3">
                         <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--color-text-secondary)]">Preflop</p>
-                        <div className="flex items-center justify-center gap-1.5">
+                        <div className="flex items-center justify-center -space-x-2 scale-105">
                             {[0, 1, 2, 3, 4].map((i) => (
                                 <div key={i} className="card-mini card-placeholder scale-75 opacity-40">
                                     <span className="text-base">?</span>

--- a/next-poker-app/app/play/components/PlayPhase.tsx
+++ b/next-poker-app/app/play/components/PlayPhase.tsx
@@ -236,15 +236,20 @@ export default function PlayPhase({
                         center={(
                             <div className="flex flex-col items-center gap-2">
                                 <p className="text-[10px] text-[var(--color-text-secondary)] uppercase tracking-[0.18em]">{street}</p>
-                                <div className="flex flex-wrap justify-center gap-1.5">
-                                    {communityCards.length > 0 ? communityCards.map((c, i) => (
-                                        <div key={i} className={`card-mini suit-${c.suit} scale-90 origin-left`}>
-                                            <span className="card-rank">{c.rank}</span>
-                                            <span className="card-suit">{suitSym(c.suit)}</span>
-                                        </div>
-                                    )) : (
-                                        <p className="text-xs text-slate-500 italic">No board yet</p>
-                                    )}
+                                <div className="flex items-center justify-center -space-x-2 scale-105">
+                                    {[0, 1, 2, 3, 4].map((i) => {
+                                        const c = communityCards[i];
+                                        return c ? (
+                                            <div key={i} className={`card-mini suit-${c.suit} scale-75`}>
+                                                <span className="card-rank">{c.rank}</span>
+                                                <span className="card-suit">{suitSym(c.suit)}</span>
+                                            </div>
+                                        ) : (
+                                            <div key={i} className="card-mini card-placeholder scale-75 opacity-40">
+                                                <span className="text-base">?</span>
+                                            </div>
+                                        );
+                                    })}
                                 </div>
                                 <div className="flex items-center gap-3 text-xs font-semibold text-[var(--color-text-primary)]">
                                     <span>Pot {pot}</span>

--- a/next-poker-app/app/play/components/PlayPhase.tsx
+++ b/next-poker-app/app/play/components/PlayPhase.tsx
@@ -198,7 +198,7 @@ export default function PlayPhase({
 
     return (
         <div className="flex-1 flex flex-col">
-            <header className="p-2 px-3 flex justify-between items-center border-b border-[var(--color-border-color)] bg-slate-950/30 sticky top-0 z-10">
+            <header className="p-2 px-3 flex justify-between items-center border-b border-[var(--color-border-color)] bg-slate-950/30">
                 <div className="flex flex-col gap-0">
                     <div className="flex items-center gap-1.5">
                         <span className="text-base text-[var(--color-accent)]">{"\u2660"}</span>
@@ -473,10 +473,10 @@ export default function PlayPhase({
             {resultFlash && (
                 <div
                     className={`fixed top-2 left-1/2 -translate-x-1/2 z-30 px-3 py-1 rounded-lg border shadow-lg ${resultFlash.result === 'won'
-                            ? 'border-emerald-400/60 bg-emerald-500/20 text-emerald-200'
-                            : resultFlash.result === 'lost'
-                                ? 'border-red-400/60 bg-red-500/20 text-red-200'
-                                : 'border-slate-400/60 bg-slate-700/30 text-slate-100'
+                        ? 'border-emerald-400/60 bg-emerald-500/20 text-emerald-200'
+                        : resultFlash.result === 'lost'
+                            ? 'border-red-400/60 bg-red-500/20 text-red-200'
+                            : 'border-slate-400/60 bg-slate-700/30 text-slate-100'
                         }`}
                 >
                     <p className="text-xs font-bold">

--- a/next-poker-app/app/play/components/TableVisual.tsx
+++ b/next-poker-app/app/play/components/TableVisual.tsx
@@ -11,6 +11,7 @@ export type TableSeatVisual = {
     tone: SeatTone;
     onClick?: (() => void) | null;
     disabled?: boolean;
+    isDealer?: boolean;
 };
 
 type TableVisualProps = {
@@ -44,13 +45,13 @@ export default function TableVisual({ seats, center }: TableVisualProps) {
     const seatMap = new Map(seats.map((seat) => [seat.seat, seat]));
 
     return (
-        <section className="w-full rounded-[2rem] border border-[var(--color-border-color)] bg-[var(--color-surface)]/85 p-4 shadow-[0_24px_80px_rgba(0,0,0,0.35)]">
-            <div className="relative mx-auto h-[24rem] max-w-4xl">
-                <div className="absolute inset-8 rounded-[999px] border border-emerald-500/15 bg-[radial-gradient(circle_at_center,rgba(16,185,129,0.18),rgba(2,6,23,0.2)_60%,rgba(2,6,23,0.92)_100%)] shadow-[inset_0_0_40px_rgba(16,185,129,0.12)]" />
+        <section className="w-full rounded-[2rem] border border-[var(--color-border-color)] bg-[var(--color-surface)]/85 p-6 shadow-[0_24px_80px_rgba(0,0,0,0.35)]">
+            <div className="relative mx-auto h-[28rem] max-w-4xl">
+                <div className="absolute inset-4 rounded-[999px] border border-emerald-500/15 bg-[radial-gradient(circle_at_center,rgba(16,185,129,0.18),rgba(2,6,23,0.2)_60%,rgba(2,6,23,0.92)_100%)] shadow-[inset_0_0_40px_rgba(16,185,129,0.12)]" />
                 <div className="absolute inset-[4.5rem] rounded-[999px] border border-white/5 bg-slate-950/35" />
 
                 <div className="absolute inset-[5.25rem] flex items-center justify-center px-6">
-                    <div className="w-full max-w-sm rounded-[2rem] border border-white/8 bg-slate-950/55 px-5 py-4 text-center shadow-[inset_0_0_30px_rgba(15,23,42,0.45)] backdrop-blur-sm">
+                    <div className="w-110 max-w-sm rounded-[2rem] border border-white/8 bg-slate-950/55 px-5 py-4 text-center shadow-[inset_0_0_30px_rgba(15,23,42,0.45)] backdrop-blur-sm">
                         {center}
                     </div>
                 </div>
@@ -73,8 +74,16 @@ export default function TableVisual({ seats, center }: TableVisualProps) {
                             key={seat}
                             onClick={() => data.onClick?.()}
                             disabled={!clickable}
-                            className={`absolute ${className} flex h-24 w-24 -translate-y-1/2 flex-col items-center justify-center rounded-3xl border text-center transition-all duration-200 ${seatToneClass(data.tone, disabled)} ${clickable ? 'hover:scale-[1.03]' : ''}`}
+                            className={`absolute ${className} flex h-24 w-24 flex-col items-center justify-center rounded-3xl border text-center transition-all duration-200 ${seatToneClass(data.tone, disabled)} ${clickable ? 'hover:scale-[1.03]' : ''}`}
                         >
+                            {data.isDealer && (
+                                <span
+                                    className="absolute -top-2 -right-2 z-10 flex h-6 w-6 items-center justify-center rounded-full border-2 border-slate-900 bg-white text-[9px] font-black text-slate-900 shadow-md"
+                                    title="Dealer Button"
+                                >
+                                    D
+                                </span>
+                            )}
                             <span className="text-[10px] font-bold uppercase tracking-[0.18em]">{data.title}</span>
                             <span className="mt-1 px-1 text-[11px] font-semibold text-white/90">{data.subtitle}</span>
                             <span className="mt-1 px-1 text-[9px] uppercase tracking-[0.15em] text-white/60">

--- a/next-poker-app/app/play/layout.tsx
+++ b/next-poker-app/app/play/layout.tsx
@@ -20,7 +20,7 @@ export default function PlayLayout({
     return (
         <div className="design-page-wrapper">
             <div className="design-mobile-container">
-                <div className="w-full max-w-[480px] min-h-screen flex flex-col relative no-select [background:radial-gradient(circle_at_top_right,rgba(59,130,246,0.1),transparent_40%),radial-gradient(circle_at_bottom_left,rgba(16,185,129,0.05),transparent_40%)]">
+                <div className="w-full max-w-[480px] h-screen flex flex-col relative no-select" style={{ background: 'radial-gradient(circle at top right, rgba(59,130,246,0.1), transparent 40%), radial-gradient(circle at bottom left, rgba(16,185,129,0.05), transparent 40%)', backgroundAttachment: 'fixed' }}>
                     {children}
                 </div>
             </div>

--- a/next-poker-app/app/play/layout.tsx
+++ b/next-poker-app/app/play/layout.tsx
@@ -20,7 +20,7 @@ export default function PlayLayout({
     return (
         <div className="design-page-wrapper">
             <div className="design-mobile-container">
-                <div className="w-full max-w-[480px] h-screen flex flex-col relative no-select [background:radial-gradient(circle_at_top_right,rgba(59,130,246,0.1),transparent_40%),radial-gradient(circle_at_bottom_left,rgba(16,185,129,0.05),transparent_40%)]">
+                <div className="w-full max-w-[480px] min-h-screen flex flex-col relative no-select [background:radial-gradient(circle_at_top_right,rgba(59,130,246,0.1),transparent_40%),radial-gradient(circle_at_bottom_left,rgba(16,185,129,0.05),transparent_40%)]">
                     {children}
                 </div>
             </div>

--- a/next-poker-app/app/play/page.tsx
+++ b/next-poker-app/app/play/page.tsx
@@ -892,6 +892,11 @@ export default function PlayPage() {
     }, [fetchLegalActions, saveSession, stepAction]);
 
     const selectCard = useCallback((rank: string, suit: string) => {
+        if (pickingFor === 'community' && hand.communityCards.length >= 5) {
+            setPendingRank(null);
+            return;
+        }
+
         const card: Card = { rank, suit };
         pushHistory(`Select ${rank}${suitSym(suit)}`);
 
@@ -958,8 +963,39 @@ export default function PlayPage() {
             }
         } else if (pickingFor === 'community') {
             const newComm = [...hand.communityCards, card];
-            const street = getStreetFromBoardCount(newComm.length);
-            setHand((prev) => ({ ...prev, communityCards: newComm, street }));
+            const newStreet = getStreetFromBoardCount(newComm.length);
+
+            // At each street boundary (flop=3, turn=4, river=5), close the picker
+            // and start a new betting round automatically.
+            const isStreetBoundary = newComm.length === 3 || newComm.length === 4 || newComm.length === 5;
+            if (isStreetBoundary) {
+                const players = hand.players.map((p) => ({ ...p, bet: 0, has_acted: false }));
+                const firstToAct = players.length === 2
+                    ? firstActivePlayerFrom(players, 1)
+                    : firstActivePlayerFrom(players, 0);
+
+                setPickingFor(null);
+                setShowRaiseInput(false);
+                setRaiseInput('');
+                setHand((prev) => ({
+                    ...prev,
+                    communityCards: newComm,
+                    street: newStreet,
+                    players,
+                    currentBet: 0,
+                    currentPlayerIdx: firstToAct,
+                    streetRaiseCount: 0,
+                    cvReads: primeCvReadWindow(prev.cvReads, players, firstToAct),
+                    botResponse: null,
+                }));
+                setIsShowdownMode(false);
+                setShowdownEntries([]);
+                setShowdownResult(null);
+                setShowdownError(null);
+                setLegalActions(EMPTY_LEGAL_ACTIONS);
+            } else {
+                setHand((prev) => ({ ...prev, communityCards: newComm, street: newStreet }));
+            }
         }
 
         setPendingRank(null);
@@ -1418,6 +1454,7 @@ export default function PlayPage() {
             subtitle: isBot ? 'Bot' : isConnected ? (seatNames[String(seat)]?.trim() || `Player ${seat + 1}`) : isManual ? 'Manual Player' : 'Open',
             detail: role ?? (isBot ? 'Host' : isConnected ? 'Webcam' : isManual ? 'Host Seated' : 'Available'),
             tone: isBot ? 'bot' : isConnected ? 'connected' : isManual ? 'manual' : 'open',
+            isDealer: role === 'BTN' || role === 'SB/BTN',
             onClick: phase === 'deal-hole' && !isConnected && !isBot ? () => handleSeatLobbyClick(seat) : null,
             disabled: phase !== 'deal-hole' || isConnected || isBot,
         };
@@ -1442,7 +1479,13 @@ export default function PlayPage() {
             title: getSeatLabel(seat),
             subtitle: displayName,
             detail: `${role} | ${player.stack}${player.bet > 0 ? ` bet ${player.bet}` : ''}`,
-            tone: player.is_bot ? 'bot' : !player.is_active ? 'folded' : seatEntry.compactPosition === hand.currentPlayerIdx ? 'active' : 'normal',
+            isDealer: role === 'BTN' || role === 'SB/BTN',
+            tone: (() => {
+                const isCurrentActor = seatEntry.compactPosition === hand.currentPlayerIdx;
+                if (isCurrentActor) return player.is_bot ? 'bot' : 'active';
+                if (!player.is_active) return 'folded';
+                return 'normal';
+            })(),
         };
     });
     const showEndGameButton = phase !== 'resume-prompt'


### PR DESCRIPTION
# /play Page — Branch Changes
**Branch:** `resolve-issues-center-component`

---

## 1. Community Card Limit (Max 5)
**Files:** `app/play/page.tsx`, `app/play/components/CardSelector.tsx`

- The river/board card picker is now capped at **5 community cards**.
- An early guard in `selectCard` returns immediately if `communityCards.length >= 5` while `pickingFor === 'community'`.
- `CardSelector` now shows a message — *"Maximum 5 community cards reached. Click Confirm to continue"* — instead of the rank grid when the limit is hit.

---

## 2. Street-Boundary Auto-Confirm (Flop → Turn → River)
**File:** `app/play/page.tsx`

Previously the card picker stayed open and allowed selecting all 5 community cards in one session. Now:
- After the **3rd card** (flop), the picker closes automatically and a new betting round starts.
- After the **4th card** (turn), the picker closes and another betting round starts.
- After the **5th card** (river), the picker closes and the final betting round starts.

The turn and river cards can **only be selected after all players have acted** in the prior betting round, enforced by the existing `currentPlayerIdx === -1` effect gate.

---

## 3. Consistent Board Card Display
**Files:** `app/play/components/PlayPhase.tsx`, `app/play/components/DealHoleCards.tsx`

- Both the **Preflop** setup screen and the **play-phase** table now always render **5 card slots**, using identical placeholder cards (`card-placeholder scale-75 opacity-40`) for unfilled positions.
- Selected cards use the **same `scale-75`** as the placeholders — eliminating the size mismatch between picked cards and empty slots.
- Both containers use `-space-x-2 scale-105` for consistent overlap and sizing.
- Removed the "No board yet" italic text in favor of the unified placeholder row.

---

## 4. Seat Highlighting — Active Player Only
**File:** `app/play/page.tsx`

Reworked the seat tone priority so only the **current actor** is highlighted:

| State | Tone |
|---|---|
| Currently acting (bot) | `'bot'` (emerald glow) |
| Currently acting (opponent) | `'active'` (accent ring) |
| Folded / inactive | `'folded'` (dimmed) |
| Idle | `'normal'` (neutral) |

Previously, the bot seat always showed the emerald glow even when it was an opponent's turn.

---

## 5. Dealer Button Icon
**Files:** `app/play/components/TableVisual.tsx`, `app/play/page.tsx`

- Added `isDealer?: boolean` to the `TableSeatVisual` type.
- The seat whose role is `'BTN'` or `'SB/BTN'` (heads-up) now renders a white **"D"** chip badge in the top-right corner of the seat card.
- Applies on both the **deal-hole** setup screen and during **play**.

---

## 6. Header No Longer Sticky
**File:** `app/play/components/PlayPhase.tsx`

Removed `sticky top-0 z-10` from the PokerBot header so it scrolls naturally with the page instead of remaining pinned.

---

## 7. Globals / Layout — Overflow & Scrolling
**Files:** `app/globals.css`, `app/play/layout.tsx`

- `.design-page-wrapper` changed from `overflow: hidden; height: 100vh` to `overflow-x: hidden; overflow-y: auto; min-height: 100vh` to permit vertical page scroll.
- Play layout inner container reverted to `h-screen` (needed to bound the flex chain for inner-scroll option).

