### PR TITLE
Bug fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
       context: .
       dockerfile: backend/Dockerfile
     network_mode: "host"
+    # ports:
+    #   - "8000:8000"
     volumes:
       # Mount backend source for hot-reload during development
       - ./backend:/app/backend
@@ -17,6 +19,7 @@ services:
       - ENABLE_POKER_ROUTER=1
       - ENABLE_POKER_PRELOAD=0
       - REDIS_URL=redis://127.0.0.1:6379
+      # - REDIS_URL=redis://redis:6379
     # --reload watches for file changes and auto-restarts uvicorn
     command: ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
-    ports:
-      - "8000:8000"
+    network_mode: "host"
     volumes:
       # Mount backend source for hot-reload during development
       - ./backend:/app/backend
@@ -17,7 +16,7 @@ services:
     environment:
       - ENABLE_POKER_ROUTER=1
       - ENABLE_POKER_PRELOAD=0
-      - REDIS_URL=redis://redis:6379
+      - REDIS_URL=redis://127.0.0.1:6379
     # --reload watches for file changes and auto-restarts uvicorn
     command: ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     restart: unless-stopped

--- a/next-poker-app/app/globals.css
+++ b/next-poker-app/app/globals.css
@@ -20,16 +20,17 @@
   }
 }
 
-html, body {
-  background: #020617;
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
-  min-height: 100%;
+html,
+body {
+  height: 100%;
 }
 
 body {
   background: #020617;
+  color: var(--foreground);
+  font-family: Arial, Helvetica, sans-serif;
 }
+
 
 @theme {
   --color-surface: rgba(255, 255, 255, 0.05);
@@ -134,7 +135,6 @@ body {
   -webkit-font-smoothing: antialiased;
   background-image: linear-gradient(135deg, #0f172a 0%, #020617 100%);
   background-attachment: fixed;
-  background-size: cover;
   display: flex;
   justify-content: center;
 }
@@ -142,6 +142,7 @@ body {
 .design-mobile-container {
   max-width: 480px;
   width: 100%;
+  min-height: 100vh;
   position: relative;
   box-shadow: 0 0 40px rgba(0, 0, 0, 0.5);
 }
@@ -160,17 +161,19 @@ body {
   font-size: 13px;
   background: #fff;
   color: #1e293b;
-  border: 1px solid rgba(255,255,255,0.8);
-  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
   position: relative;
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
-.card-mini.suit-h, .card-mini.suit-d {
+.card-mini.suit-h,
+.card-mini.suit-d {
   color: #ef4444;
 }
 
-.card-mini.suit-s, .card-mini.suit-c {
+.card-mini.suit-s,
+.card-mini.suit-c {
   color: #1e293b;
 }
 
@@ -187,18 +190,32 @@ body {
 }
 
 .card-mini.card-placeholder {
-  background: rgba(255,255,255,0.08);
-  border: 2px dashed rgba(255,255,255,0.2);
-  color: rgba(255,255,255,0.25);
+  background: rgba(255, 255, 255, 0.08);
+  border: 2px dashed rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.25);
   box-shadow: none;
 }
 
-.suit-btn-h, .suit-btn-d { color: #ef4444; }
-.suit-btn-s, .suit-btn-c { color: #1e293b; }
+.suit-btn-h,
+.suit-btn-d {
+  color: #ef4444;
+}
+
+.suit-btn-s,
+.suit-btn-c {
+  color: #1e293b;
+}
 
 @keyframes recommend-reveal {
-  from { opacity: 0; transform: scale(0.9) translateY(10px); }
-  to { opacity: 1; transform: scale(1) translateY(0); }
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
 }
 
 .animate-recommend {
@@ -206,8 +223,13 @@ body {
 }
 
 @keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .animate-fade-in {

--- a/next-poker-app/app/page.tsx
+++ b/next-poker-app/app/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 export default function HomePage() {
   return (
     <div className="design-page-wrapper">
-      <div className="design-mobile-container flex flex-col items-center justify-center px-4 md:px-6 relative overflow-hidden h-full">
+      <div className="design-mobile-container flex flex-col items-center justify-center px-4 md:px-6 relative overflow-hidden">
         {/* Subtle decorative background elements */}
         <div className="pointer-events-none absolute -top-40 -left-40 h-80 w-80 rounded-full bg-emerald-500/10 blur-[100px]" />
         <div className="pointer-events-none absolute -bottom-40 -right-40 h-80 w-80 rounded-full bg-blue-500/10 blur-[100px]" />

--- a/next-poker-app/app/play/components/DealPosition.tsx
+++ b/next-poker-app/app/play/components/DealPosition.tsx
@@ -76,6 +76,14 @@ export default function DealPosition({
                                 <span className="mt-1 text-[10px] uppercase tracking-[0.16em] text-white/55">
                                     {role ?? (isBotSeat ? 'Waiting' : isConnectedSeat ? 'Webcam' : isManualSeat ? 'Host Seated' : 'Empty')}
                                 </span>
+                                {isBotSeat && (
+                                    <span
+                                        className="absolute -top-2 -left-2 z-10 flex h-6 w-6 items-center justify-center rounded-full border-2 border-slate-900 bg-amber-400 text-[11px] shadow-[0_0_8px_rgba(251,191,36,0.6)]"
+                                        title="Host"
+                                    >
+                                        👑
+                                    </span>
+                                )}
                             </button>
                         );
                     })}

--- a/next-poker-app/app/play/components/TableVisual.tsx
+++ b/next-poker-app/app/play/components/TableVisual.tsx
@@ -12,6 +12,7 @@ export type TableSeatVisual = {
     onClick?: (() => void) | null;
     disabled?: boolean;
     isDealer?: boolean;
+    isBot?: boolean;
 };
 
 type TableVisualProps = {
@@ -82,6 +83,14 @@ export default function TableVisual({ seats, center }: TableVisualProps) {
                                     title="Dealer Button"
                                 >
                                     D
+                                </span>
+                            )}
+                            {(data.isBot || data.tone === 'bot') && (
+                                <span
+                                    className="absolute -top-2 -left-2 z-10 flex h-6 w-6 items-center justify-center rounded-full border-2 border-slate-900 bg-amber-400 text-[11px] shadow-[0_0_8px_rgba(251,191,36,0.6)]"
+                                    title="Host"
+                                >
+                                    👑
                                 </span>
                             )}
                             <span className="text-[10px] font-bold uppercase tracking-[0.18em]">{data.title}</span>

--- a/next-poker-app/app/play/page.tsx
+++ b/next-poker-app/app/play/page.tsx
@@ -1480,6 +1480,7 @@ export default function PlayPage() {
             subtitle: displayName,
             detail: `${role} | ${player.stack}${player.bet > 0 ? ` bet ${player.bet}` : ''}`,
             isDealer: role === 'BTN' || role === 'SB/BTN',
+            isBot: player.is_bot,
             tone: (() => {
                 const isCurrentActor = seatEntry.compactPosition === hand.currentPlayerIdx;
                 if (isCurrentActor) return player.is_bot ? 'bot' : 'active';


### PR DESCRIPTION
## Summary

This PR resolves two UI bugs:

1. **Landing page height not filling the full viewport** — the home page was clipping short on taller devices because `min-height: 100%` was not propagating correctly through the CSS cascade.
2. **No visual indicator for the host seat** — there was no way to distinguish which seat belonged to the bot/host when looking at the table.
---

## Changes

###  Fix: Landing page full-height layout (`landing page length fix`)

**Files changed:** `globals.css`, `app/page.tsx`

- Split `html, body` into separate rules and set `html, body { height: 100% }` so that percentage-based heights cascade properly.
- Moved `background`, `color`, and `font-family` into the `body`-only rule to avoid conflicts.
- Removed `background-size: cover` from `.design-page-wrapper` (redundant and incorrect for `background-attachment: fixed`).
- Added `min-height: 100vh` to `.design-mobile-container` so the column always fills at least the full viewport height.
- Removed the inline `h-full` Tailwind class from the mobile container in `page.tsx`, deferring height control to CSS.
- Minor CSS formatting cleanup: expanded single-line rules (keyframes, selector groups) into multi-line blocks for readability.

###  Fix: Crown indicator for host seat (`add crown for host seat`)

**Files changed:** `app/play/components/TableVisual.tsx`, `app/play/components/DealPosition.tsx`, `app/play/page.tsx`

- Added an `isBot` boolean field to `TableSeatVisual` type in `TableVisual.tsx`.
- Render a small amber crown badge (👑, absolute-positioned top-left) on any seat where `isBot` is true or `tone === 'bot'`, in both the `TableVisual` and `DealPosition` components.
- Passed `player.is_bot` through from `PlayPage` to each seat's visual props so the data flows from the game state down to the UI.

