### PR TITLE
fix join seat margins

### DIFF
--- a/next-poker-app/app/join/page.tsx
+++ b/next-poker-app/app/join/page.tsx
@@ -436,8 +436,8 @@ export default function JoinPage() {
     : isStreaming && phase !== 'live'
       ? 'bg-amber-500/20 text-amber-300 border border-amber-500/30'
       : isStreaming
-      ? 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/30'
-      : 'bg-slate-700/50 text-slate-400 border border-slate-600/30';
+        ? 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/30'
+        : 'bg-slate-700/50 text-slate-400 border border-slate-600/30';
 
   const isBusy = isJoining || isStartingWebcam || isStoppingWebcam;
 
@@ -528,15 +528,14 @@ export default function JoinPage() {
                       key={seat}
                       onClick={() => setPlayerPosition(seat)}
                       disabled={isDisabled}
-                      className={`absolute ${className} flex h-20 w-20 -translate-y-1/2 flex-col items-center justify-center rounded-3xl border text-center text-[11px] font-semibold transition-all ${
-                        isBotSeat
-                          ? 'border-sky-400/40 bg-sky-500/10 text-sky-100'
-                          : taken
-                            ? 'cursor-not-allowed border-slate-700/40 bg-slate-900/80 text-slate-500 opacity-60'
-                            : isSelected
-                              ? 'border-emerald-400 bg-emerald-500 text-slate-950 shadow-lg shadow-emerald-500/25'
-                              : 'border-slate-600/30 bg-slate-800/80 text-slate-300 hover:bg-slate-700/80 hover:border-slate-500/40'
-                      }`}
+                      className={`absolute ${className} flex h-20 w-20 flex-col items-center justify-center rounded-3xl border text-center text-[11px] font-semibold transition-all ${isBotSeat
+                        ? 'border-sky-400/40 bg-sky-500/10 text-sky-100'
+                        : taken
+                          ? 'cursor-not-allowed border-slate-700/40 bg-slate-900/80 text-slate-500 opacity-60'
+                          : isSelected
+                            ? 'border-emerald-400 bg-emerald-500 text-slate-950 shadow-lg shadow-emerald-500/25'
+                            : 'border-slate-600/30 bg-slate-800/80 text-slate-300 hover:bg-slate-700/80 hover:border-slate-500/40'
+                        }`}
                     >
                       <span className="uppercase tracking-[0.16em]">{getSeatLabel(seat)}</span>
                       <span className="mt-1 text-[10px] text-white/80">
@@ -562,7 +561,7 @@ export default function JoinPage() {
                       ? 'Waiting for the host to choose the bot seat.'
                       : hasAnyAvailableSeat
                         ? 'Choose any open seat. Grey seats are already occupied.'
-                      : 'All seats are currently taken.'}
+                        : 'All seats are currently taken.'}
                 </p>
               )}
             </div>

--- a/next-poker-app/app/lib/tablePositions.ts
+++ b/next-poker-app/app/lib/tablePositions.ts
@@ -9,12 +9,12 @@ export const tablePositionByPlayers: Record<number, string[]> = {
 export const FULL_RING_SEAT_COUNT = 6;
 
 export const sixSeatLayout = [
-  { seat: 0, className: 'left-1/2 top-0 -translate-x-1/2' },
-  { seat: 1, className: 'right-[8%] top-[15%] translate-x-1/2' },
-  { seat: 2, className: 'right-[8%] bottom-[15%] translate-x-1/2' },
-  { seat: 3, className: 'left-1/2 bottom-0 -translate-x-1/2' },
-  { seat: 4, className: 'left-[8%] bottom-[15%] -translate-x-1/2' },
-  { seat: 5, className: 'left-[8%] top-[15%] -translate-x-1/2' },
+  { seat: 0, className: 'left-1/2 top-[2%] -translate-x-1/2' },
+  { seat: 1, className: 'right-[14%] top-[15%] translate-x-1/2' },
+  { seat: 2, className: 'right-[14%] bottom-[15%] translate-x-1/2' },
+  { seat: 3, className: 'left-1/2 bottom-[2%] -translate-x-1/2' },
+  { seat: 4, className: 'left-[14%] bottom-[15%] -translate-x-1/2' },
+  { seat: 5, className: 'left-[14%] top-[15%] -translate-x-1/2' },
 ] as const;
 
 export function getTablePosition(position: number, tableSize: number): string {


### PR DESCRIPTION
# Alignment Fixes for Join Page Seats

## Changes
* **Fixed Vertical Symmetry:** Removed an incorrect `-translate-y-1/2` class in `/join` that was shifting all seats upward and breaking layout bounds.
* **Tighter Layout Insets:** Updated `sixSeatLayout` to hug the central oval more closely: side seats are pulled inward to `14%` (from `8%`), and top/bottom seats are inset by `2%`.

